### PR TITLE
Switch back to a stable sort

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ impl<Tuple: Ord> Relation<Tuple> {
     }
 
     fn from_vec(mut elements: Vec<Tuple>) -> Self {
-        elements.sort_unstable();
+        elements.sort();
         elements.dedup();
         Relation { elements }
     }


### PR DESCRIPTION
I was testing rayon's parallel sort on Relations when I noticed we were using std's `sort_unstable` even though we (albeit not completely 100% sure why) saw the stable sort perform better. So let's bring it back until we have more measurements/benchmarks :)

This locally improves, on `clap`:
- the `DatafrogOpt` variant from 5.8s to 5.4s
- the `Leapfrog` variant from 4.2s to 4s 
- the `LocationInsensitive` variant from 800ms to 410ms (this one convinced me to open the PR as a combination of it with leapfrog is likely going to be the way to go)