### PR TITLE
Specialize creating Relations from Vecs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 //! normal Rust program, run to completion, and then the results extracted as
 //! vectors again.
 
+#![feature(specialization)]
 #![forbid(missing_docs)]
 
 use std::rc::Rc;
@@ -92,8 +93,14 @@ impl<Tuple: Ord> Relation<Tuple> {
 }
 
 impl<Tuple: Ord, I: IntoIterator<Item=Tuple>> From<I> for Relation<Tuple> {
-    fn from(iterator: I) -> Self {
+    default fn from(iterator: I) -> Self {
         Relation::from_vec(iterator.into_iter().collect())
+    }
+}
+
+impl<Tuple: Ord> From<Vec<Tuple>> for Relation<Tuple> {
+    fn from(v: Vec<Tuple>) -> Self {
+        Relation::from_vec(v)
     }
 }
 


### PR DESCRIPTION
While this makes 🐸 rely on an unstable feature, it can help avoiding consuming Vecs and collecting them immediately afterwards.

For example, it should prevent 81k of such cases in Polonius' `clap` benchmark, for the `datafrogopt` variant. (It's not a _huge_ time saving in this case, but still)

Thoughts ? (especially if we'd want to add a `rust-toolchain` file, or still support stable by having different functions for `IntoInter` and `Vec`)