### PR TITLE
Predicate leaper [WIP]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod treefrog;
 pub use treefrog::{
     extend_anti::ExtendAnti, extend_with::ExtendWith, filter_anti::FilterAnti,
     filter_with::FilterWith, Leaper, RelationLeaper,
+    filters::{PrefixFilter, ValueFilter},
 };
 
 /// A static, ordered list of key-value pairs.


### PR DESCRIPTION
This PR introduces `treefrog::filters::{PrefixFilter, ValueFilter}`, each of which implement `Leaper`. The first is constructed from a `fn(&Tuple) -> bool` and the second from a `fn(&Tuple, &Val) -> bool`. Each of them do the very simple action you would expect, the first one ruling out extensions based on `prefix`  and the second filtering `values` down using the predicate.