### PR TITLE
Proposal: extend API to support more operations on relations [breaking change]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ edition = "2018"
 [badges]
 is-it-maintained-issue-resolution = { repository = "https://github.com/rust-lang-nursery/datafrog" }
 is-it-maintained-open-issues = { repository = "https://github.com/rust-lang-nursery/datafrog" }
+
+[dev-dependencies]
+proptest = "0.8.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "Lightweight Datalog engine intended to be embedded in other Rust 
 readme = "README.md"
 keywords = ["datalog", "analysis"]
 repository = "https://github.com/rust-lang-nursery/datafrog"
+edition = "2018"
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "https://github.com/rust-lang-nursery/datafrog" }

--- a/src/join.rs
+++ b/src/join.rs
@@ -116,7 +116,7 @@ pub(crate) fn gallop<T>(mut slice: &[T], mut cmp: impl FnMut(&T) -> bool) -> &[T
     slice
 }
 
-pub(crate) trait JoinInput<'me, Tuple: Ord>: Copy {
+pub trait JoinInput<'me, Tuple: Ord>: Copy {
     type RecentTuples: Deref<Target = [Tuple]>;
     type StableTuples: Deref<Target = [Relation<Tuple>]>;
 
@@ -134,5 +134,18 @@ impl<'me, Tuple: Ord> JoinInput<'me, Tuple> for &'me Variable<Tuple> {
 
     fn stable(self) -> Self::StableTuples {
         Ref::map(self.stable.borrow(), |v| &v[..])
+    }
+}
+
+impl<'me, Tuple: Ord> JoinInput<'me, Tuple> for &'me Relation<Tuple> {
+    type RecentTuples = &'me [Tuple];
+    type StableTuples = &'me [Relation<Tuple>];
+
+    fn recent(self) -> Self::RecentTuples {
+        &[]
+    }
+
+    fn stable(self) -> Self::StableTuples {
+        std::slice::from_ref(self)
     }
 }

--- a/src/join.rs
+++ b/src/join.rs
@@ -4,7 +4,7 @@ use super::{Relation, Variable};
 use std::cell::Ref;
 use std::ops::Deref;
 
-pub trait JoinInput<'me, Tuple: Ord>: Copy {
+pub(crate) trait JoinInput<'me, Tuple: Ord>: Copy {
     type RecentTuples: Deref<Target = Relation<Tuple>>;
     type StableTuples: Deref<Target = Vec<Relation<Tuple>>>;
 
@@ -25,7 +25,7 @@ impl<'me, Tuple: Ord> JoinInput<'me, Tuple> for &'me Variable<Tuple> {
     }
 }
 
-pub fn join_into<'me, Key: Ord, Val1: Ord, Val2: Ord, Result: Ord>(
+pub(crate) fn join_into<'me, Key: Ord, Val1: Ord, Val2: Ord, Result: Ord>(
     input1: impl JoinInput<'me, (Key, Val1)>,
     input2: impl JoinInput<'me, (Key, Val2)>,
     output: &Variable<Result>,
@@ -56,7 +56,7 @@ pub fn join_into<'me, Key: Ord, Val1: Ord, Val2: Ord, Result: Ord>(
 }
 
 /// Moves all recent tuples from `input1` that are not present in `input2` into `output`.
-pub fn antijoin_into<Key: Ord, Val: Ord, Result: Ord>(
+pub(crate) fn antijoin_into<Key: Ord, Val: Ord, Result: Ord>(
     input1: &Variable<(Key, Val)>,
     input2: &Relation<Key>,
     output: &Variable<Result>,
@@ -114,7 +114,7 @@ fn join_helper<K: Ord, V1, V2>(
     }
 }
 
-pub fn gallop<T>(mut slice: &[T], mut cmp: impl FnMut(&T) -> bool) -> &[T] {
+pub(crate) fn gallop<T>(mut slice: &[T], mut cmp: impl FnMut(&T) -> bool) -> &[T] {
     // if empty slice, or already >= element, return
     if !slice.is_empty() && cmp(&slice[0]) {
         let mut step = 1;

--- a/src/join.rs
+++ b/src/join.rs
@@ -4,8 +4,13 @@ use super::{Relation, Variable};
 use std::cell::Ref;
 use std::ops::Deref;
 
+/// Implements `join`. Note that `input1` must be a variable, but
+/// `input2` can be either a variable or a relation. This is necessary
+/// because relations have no "recent" tuples, so the fn would be a
+/// guaranteed no-op if both arguments were relations.  See also
+/// `join_into_relation`.
 pub(crate) fn join_into<'me, Key: Ord, Val1: Ord, Val2: Ord, Result: Ord>(
-    input1: impl JoinInput<'me, (Key, Val1)>,
+    input1: &Variable<(Key, Val1)>,
     input2: impl JoinInput<'me, (Key, Val2)>,
     output: &Variable<Result>,
     mut logic: impl FnMut(&Key, &Val1, &Val2) -> Result,
@@ -34,6 +39,7 @@ pub(crate) fn join_into<'me, Key: Ord, Val1: Ord, Val2: Ord, Result: Ord>(
     output.insert(Relation::from_vec(results));
 }
 
+/// Join, but for two relations.
 pub(crate) fn join_into_relation<'me, Key: Ord, Val1: Ord, Val2: Ord, Result: Ord>(
     input1: &Relation<(Key, Val1)>,
     input2: &Relation<(Key, Val2)>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,16 @@ impl<Tuple: Ord> Relation<Tuple> {
         Relation { elements }
     }
 
+    /// Creates a `Relation` from the elements of the `iterator`.
+    ///
+    /// Same as the `from_iter` method from `std::iter::FromIterator` trait.
+    pub fn from_iter<I>(iterator: I) -> Self
+    where
+        I: IntoIterator<Item = Tuple>
+    {
+        iterator.into_iter().collect()
+    }
+
     /// Creates a `Relation` using the `leapjoin` logic;
     /// see [`Variable::leapjoin`]
     pub fn from_leapjoin<'a, SourceTuple: Ord, Val: Ord + 'a>(
@@ -138,7 +148,7 @@ impl<Tuple: Ord> Relation<Tuple> {
     /// Construct a new relation by mapping another one. Equivalent to
     /// creating an iterator but perhaps more convenient. Analogous to
     /// `Variable::from_map`.
-    pub fn from_map<T2: Ord>(&self, input: &Relation<T2>, logic: impl FnMut(&T2) -> Tuple) -> Self {
+    pub fn from_map<T2: Ord>(input: &Relation<T2>, logic: impl FnMut(&T2) -> Tuple) -> Self {
         input.iter().map(logic).collect()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,8 @@ pub struct Relation<Tuple: Ord> {
 impl<Tuple: Ord> Relation<Tuple> {
     /// Merges two relations into their union.
     pub fn merge(self, other: Self) -> Self {
-        let mut elements1 = self.elements;
-        let mut elements2 = other.elements;
+        let Relation { elements: mut elements1 } = self;
+        let Relation { elements: mut elements2 } = other;
 
         // If one of the element lists is zero-length, we don't need to do any work
         if elements1.is_empty() {
@@ -133,6 +133,13 @@ impl<Tuple: Ord> Relation<Tuple> {
         logic: impl FnMut(&Key, &Val1) -> Tuple,
     ) -> Self {
         join::antijoin(input1, input2, logic)
+    }
+
+    /// Construct a new relation by mapping another one. Equivalent to
+    /// creating an iterator but perhaps more convenient. Analogous to
+    /// `Variable::from_map`.
+    pub fn from_map<T2: Ord>(&self, input: &Relation<T2>, logic: impl FnMut(&T2) -> Tuple) -> Self {
+        input.iter().map(logic).collect()
     }
 
     /// Creates a `Relation` from a vector of tuples.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,8 +285,8 @@ impl<Tuple: Ord> Variable<Tuple> {
     ///
     /// let mut iteration = Iteration::new();
     /// let variable = iteration.variable::<(usize, usize)>("source");
-    /// variable.insert((0 .. 10).map(|x| (x, x + 1)).collect());
-    /// variable.insert((0 .. 10).map(|x| (x + 1, x)).collect());
+    /// variable.extend((0 .. 10).map(|x| (x, x + 1)));
+    /// variable.extend((0 .. 10).map(|x| (x + 1, x)));
     ///
     /// while iteration.changed() {
     ///     variable.from_join(&variable, &variable, |&key, &val1, &val2| (val1, val2));
@@ -322,7 +322,7 @@ impl<Tuple: Ord> Variable<Tuple> {
     ///
     /// let mut iteration = Iteration::new();
     /// let variable = iteration.variable::<(usize, usize)>("source");
-    /// variable.insert((0 .. 10).map(|x| (x, x + 1)).collect());
+    /// variable.extend((0 .. 10).map(|x| (x, x + 1)));
     ///
     /// let relation: Relation<_> = (0 .. 10).filter(|x| x % 3 == 0).collect();
     ///
@@ -356,7 +356,7 @@ impl<Tuple: Ord> Variable<Tuple> {
     ///
     /// let mut iteration = Iteration::new();
     /// let variable = iteration.variable::<(usize, usize)>("source");
-    /// variable.insert((0 .. 10).map(|x| (x, x)).collect());
+    /// variable.extend((0 .. 10).map(|x| (x, x)));
     ///
     /// while iteration.changed() {
     ///     variable.from_map(&variable, |&(key, val)|
@@ -434,6 +434,7 @@ impl<Tuple: Ord> Variable<Tuple> {
             to_add: Rc::new(RefCell::new(Vec::new())),
         }
     }
+
     /// Inserts a relation into the variable.
     ///
     /// This is most commonly used to load initial values into a variable.
@@ -444,6 +445,18 @@ impl<Tuple: Ord> Variable<Tuple> {
             self.to_add.borrow_mut().push(relation);
         }
     }
+
+    /// Extend the variable with values from the iterator.
+    ///
+    /// This is most commonly used to load initial values into a variable.
+    /// it is not obvious that it should be commonly used otherwise, but
+    /// it should not be harmful.
+    pub fn extend<T>(&self, iterator: impl IntoIterator<Item = T>)
+        where Relation<Tuple>: FromIterator<T>
+    {
+        self.insert(iterator.into_iter().collect());
+    }
+
     /// Consumes the variable and returns a relation.
     ///
     /// This method removes the ability for the variable to develop, and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use std::rc::Rc;
 mod join;
 mod map;
 mod treefrog;
-pub use treefrog::{
+pub use crate::treefrog::{
     extend_anti::ExtendAnti,
     extend_with::ExtendWith,
     filter_anti::FilterAnti,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::rc::Rc;
+use std::iter::FromIterator;
 
 mod join;
 mod map;
@@ -134,6 +135,15 @@ impl<Tuple: Ord> Relation<Tuple> {
 
 impl<Tuple: Ord, I: IntoIterator<Item = Tuple>> From<I> for Relation<Tuple> {
     fn from(iterator: I) -> Self {
+        Self::from_iter(iterator)
+    }
+}
+
+impl<Tuple: Ord> FromIterator<Tuple> for Relation<Tuple> {
+    fn from_iter<I>(iterator: I) -> Self
+    where
+        I: IntoIterator<Item = Tuple>
+    {
         Relation::from_vec(iterator.into_iter().collect())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,8 @@
 
 use std::cell::RefCell;
 use std::cmp::Ordering;
-use std::rc::Rc;
 use std::iter::FromIterator;
+use std::rc::Rc;
 
 mod join;
 mod map;
@@ -44,8 +44,12 @@ pub struct Relation<Tuple: Ord> {
 impl<Tuple: Ord> Relation<Tuple> {
     /// Merges two relations into their union.
     pub fn merge(self, other: Self) -> Self {
-        let Relation { elements: mut elements1 } = self;
-        let Relation { elements: mut elements2 } = other;
+        let Relation {
+            elements: mut elements1,
+        } = self;
+        let Relation {
+            elements: mut elements2,
+        } = other;
 
         // If one of the element lists is zero-length, we don't need to do any work
         if elements1.is_empty() {
@@ -105,7 +109,7 @@ impl<Tuple: Ord> Relation<Tuple> {
     /// Same as the `from_iter` method from `std::iter::FromIterator` trait.
     pub fn from_iter<I>(iterator: I) -> Self
     where
-        I: IntoIterator<Item = Tuple>
+        I: IntoIterator<Item = Tuple>,
     {
         iterator.into_iter().collect()
     }
@@ -169,7 +173,7 @@ impl<Tuple: Ord> From<Vec<Tuple>> for Relation<Tuple> {
 impl<Tuple: Ord> FromIterator<Tuple> for Relation<Tuple> {
     fn from_iter<I>(iterator: I) -> Self
     where
-        I: IntoIterator<Item = Tuple>
+        I: IntoIterator<Item = Tuple>,
     {
         Relation::from_vec(iterator.into_iter().collect())
     }
@@ -178,7 +182,7 @@ impl<Tuple: Ord> FromIterator<Tuple> for Relation<Tuple> {
 impl<'tuple, Tuple: 'tuple + Copy + Ord> FromIterator<&'tuple Tuple> for Relation<Tuple> {
     fn from_iter<I>(iterator: I) -> Self
     where
-        I: IntoIterator<Item = &'tuple Tuple>
+        I: IntoIterator<Item = &'tuple Tuple>,
     {
         Relation::from_vec(iterator.into_iter().cloned().collect())
     }
@@ -469,7 +473,8 @@ impl<Tuple: Ord> Variable<Tuple> {
     /// it is not obvious that it should be commonly used otherwise, but
     /// it should not be harmful.
     pub fn extend<T>(&self, iterator: impl IntoIterator<Item = T>)
-        where Relation<Tuple>: FromIterator<T>
+    where
+        Relation<Tuple>: FromIterator<T>,
     {
         self.insert(iterator.into_iter().collect());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ use std::rc::Rc;
 
 mod join;
 mod map;
+mod test;
 mod treefrog;
 pub use crate::treefrog::{
     extend_anti::ExtendAnti,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ impl<Tuple: Ord> Relation<Tuple> {
     }
 
     /// Creates a `Relation` by removing all values from `input1` that
-    /// share a key with `input2`, and then transforming the reuslting
+    /// share a key with `input2`, and then transforming the resulting
     /// tuples with the `logic` closure. Like
     /// [`Variable::from_antijoin`] except for use where the inputs
     /// are not varying across iterations.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,9 +133,9 @@ impl<Tuple: Ord> Relation<Tuple> {
     }
 }
 
-impl<Tuple: Ord, I: IntoIterator<Item = Tuple>> From<I> for Relation<Tuple> {
-    fn from(iterator: I) -> Self {
-        Self::from_iter(iterator)
+impl<Tuple: Ord> From<Vec<Tuple>> for Relation<Tuple> {
+    fn from(iterator: Vec<Tuple>) -> Self {
+        Self::from_vec(iterator)
     }
 }
 
@@ -275,8 +275,8 @@ impl<Tuple: Ord> Variable<Tuple> {
     ///
     /// let mut iteration = Iteration::new();
     /// let variable = iteration.variable::<(usize, usize)>("source");
-    /// variable.insert(Relation::from((0 .. 10).map(|x| (x, x + 1))));
-    /// variable.insert(Relation::from((0 .. 10).map(|x| (x + 1, x))));
+    /// variable.insert((0 .. 10).map(|x| (x, x + 1)).collect());
+    /// variable.insert((0 .. 10).map(|x| (x + 1, x)).collect());
     ///
     /// while iteration.changed() {
     ///     variable.from_join(&variable, &variable, |&key, &val1, &val2| (val1, val2));
@@ -312,9 +312,9 @@ impl<Tuple: Ord> Variable<Tuple> {
     ///
     /// let mut iteration = Iteration::new();
     /// let variable = iteration.variable::<(usize, usize)>("source");
-    /// variable.insert(Relation::from((0 .. 10).map(|x| (x, x + 1))));
+    /// variable.insert((0 .. 10).map(|x| (x, x + 1)).collect());
     ///
-    /// let relation = Relation::from((0 .. 10).filter(|x| x % 3 == 0));
+    /// let relation: Relation<_> = (0 .. 10).filter(|x| x % 3 == 0).collect();
     ///
     /// while iteration.changed() {
     ///     variable.from_antijoin(&variable, &relation, |&key, &val| (val, key));
@@ -346,7 +346,7 @@ impl<Tuple: Ord> Variable<Tuple> {
     ///
     /// let mut iteration = Iteration::new();
     /// let variable = iteration.variable::<(usize, usize)>("source");
-    /// variable.insert(Relation::from((0 .. 10).map(|x| (x, x))));
+    /// variable.insert((0 .. 10).map(|x| (x, x)).collect());
     ///
     /// while iteration.changed() {
     ///     variable.from_map(&variable, |&(key, val)|

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,15 @@ impl<Tuple: Ord> FromIterator<Tuple> for Relation<Tuple> {
     }
 }
 
+impl<'tuple, Tuple: 'tuple + Copy + Ord> FromIterator<&'tuple Tuple> for Relation<Tuple> {
+    fn from_iter<I>(iterator: I) -> Self
+    where
+        I: IntoIterator<Item = &'tuple Tuple>
+    {
+        Relation::from_vec(iterator.into_iter().cloned().collect())
+    }
+}
+
 impl<Tuple: Ord> std::ops::Deref for Relation<Tuple> {
     type Target = [Tuple];
     fn deref(&self) -> &Self::Target {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,7 +398,7 @@ impl<Tuple: Ord> Variable<Tuple> {
         leapers: &mut [&mut dyn Leaper<'a, SourceTuple, Val>],
         logic: impl FnMut(&SourceTuple, &Val) -> Tuple,
     ) {
-        treefrog::leapjoin_into(source, leapers, self, logic)
+        self.insert(treefrog::leapjoin(source, leapers, logic));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,16 @@ impl<Tuple: Ord> Relation<Tuple> {
         Relation { elements }
     }
 
+    /// Creates a `Relation` using the `leapjoin` logic;
+    /// see [`Variable::leapjoin`]
+    pub fn from_leapjoin<'a, SourceTuple: Ord, Val: Ord + 'a>(
+        source: &Relation<SourceTuple>,
+        leapers: &mut [&mut dyn Leaper<'a, SourceTuple, Val>],
+        logic: impl FnMut(&SourceTuple, &Val) -> Tuple,
+    ) -> Self {
+        treefrog::leapjoin(&source.elements, leapers, logic)
+    }
+
     /// Creates a `Relation` by joining the values from `input1` and
     /// `input2` and then applying `logic`. Like
     /// [`Variable::from_join`] except for use where the inputs are
@@ -398,7 +408,7 @@ impl<Tuple: Ord> Variable<Tuple> {
         leapers: &mut [&mut dyn Leaper<'a, SourceTuple, Val>],
         logic: impl FnMut(&SourceTuple, &Val) -> Tuple,
     ) {
-        self.insert(treefrog::leapjoin(source, leapers, logic));
+        self.insert(treefrog::leapjoin(&source.recent.borrow(), leapers, logic));
     }
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -2,7 +2,7 @@
 
 use super::{Relation, Variable};
 
-pub fn map_into<T1: Ord, T2: Ord>(
+pub(crate) fn map_into<T1: Ord, T2: Ord>(
     input: &Variable<T1>,
     output: &Variable<T2>,
     logic: impl FnMut(&T1) -> T2,

--- a/src/test.rs
+++ b/src/test.rs
@@ -31,7 +31,7 @@ fn reachable_with_var_join(edges: &[(u32, u32)]) -> Relation<(u32, u32)> {
 
 /// Like `reachable`, but using a relation as an input to `from_join`
 fn reachable_with_relation_join(edges: &[(u32, u32)]) -> Relation<(u32, u32)> {
-    let edges = Relation::from(edges.iter().cloned());
+    let edges: Relation<_> = edges.iter().cloned().collect();
     let mut iteration = Iteration::new();
 
     // NB. Changed from `reachable_with_var_join`:

--- a/src/test.rs
+++ b/src/test.rs
@@ -31,7 +31,7 @@ fn reachable_with_var_join(edges: &[(u32, u32)]) -> Relation<(u32, u32)> {
 
 /// Like `reachable`, but using a relation as an input to `from_join`
 fn reachable_with_relation_join(edges: &[(u32, u32)]) -> Relation<(u32, u32)> {
-    let edges: Relation<_> = edges.iter().cloned().collect();
+    let edges: Relation<_> = edges.iter().collect();
     let mut iteration = Iteration::new();
 
     // NB. Changed from `reachable_with_var_join`:

--- a/src/test.rs
+++ b/src/test.rs
@@ -12,11 +12,11 @@ fn inputs() -> impl Strategy<Value = Vec<(u32, u32)>> {
 
 /// The original way to use datafrog -- computes reachable nodes from a set of edges
 fn reachable_with_var_join(edges: &[(u32, u32)]) -> Relation<(u32, u32)> {
-    let edges = Relation::from(edges.iter().cloned());
+    let edges: Relation<_> = edges.iter().collect();
     let mut iteration = Iteration::new();
 
     let edges_by_successor = iteration.variable::<(u32, u32)>("edges_invert");
-    edges_by_successor.insert(Relation::from(edges.iter().map(|&(n1, n2)| (n2, n1))));
+    edges_by_successor.insert(edges.iter().map(|&(n1, n2)| (n2, n1)).collect());
 
     let reachable = iteration.variable::<(u32, u32)>("reachable");
     reachable.insert(edges);
@@ -35,7 +35,7 @@ fn reachable_with_relation_join(edges: &[(u32, u32)]) -> Relation<(u32, u32)> {
     let mut iteration = Iteration::new();
 
     // NB. Changed from `reachable_with_var_join`:
-    let edges_by_successor = Relation::from(edges.iter().map(|&(n1, n2)| (n2, n1)));
+    let edges_by_successor: Relation<_> = edges.iter().map(|&(n1, n2)| (n2, n1)).collect();
 
     let reachable = iteration.variable::<(u32, u32)>("reachable");
     reachable.insert(edges);
@@ -49,10 +49,10 @@ fn reachable_with_relation_join(edges: &[(u32, u32)]) -> Relation<(u32, u32)> {
 }
 
 fn reachable_with_leapfrog(edges: &[(u32, u32)]) -> Relation<(u32, u32)> {
-    let edges = Relation::from(edges.iter().cloned());
+    let edges: Relation<_> = edges.iter().collect();
     let mut iteration = Iteration::new();
 
-    let edges_by_successor = Relation::from(edges.iter().map(|&(n1, n2)| (n2, n1)));
+    let edges_by_successor: Relation<_> = edges.iter().map(|&(n1, n2)| (n2, n1)).collect();
 
     let reachable = iteration.variable::<(u32, u32)>("reachable");
     reachable.insert(edges);
@@ -78,10 +78,10 @@ fn sum_join_via_var(
     let mut iteration = Iteration::new();
 
     let input1 = iteration.variable::<(u32, u32)>("input1");
-    input1.insert(Relation::from(input1_slice.iter().cloned()));
+    input1.insert(input1_slice.iter().collect());
 
     let input2 = iteration.variable::<(u32, u32)>("input1");
-    input2.insert(Relation::from(input2_slice.iter().cloned()));
+    input2.insert(input2_slice.iter().collect());
 
     let output = iteration.variable::<(u32, u32)>("output");
 
@@ -99,8 +99,8 @@ fn sum_join_via_relation(
     input1_slice: &[(u32, u32)],
     input2_slice: &[(u32, u32)],
 ) -> Relation<(u32, u32)> {
-    let input1 = Relation::from(input1_slice.iter().cloned());
-    let input2 = Relation::from(input2_slice.iter().cloned());
+    let input1: Relation<_> = input1_slice.iter().collect();
+    let input2: Relation<_> = input2_slice.iter().collect();
     Relation::from_join(&input1, &input2, |&k1, &v1, &v2| (k1, v1 * 100 + v2))
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -16,7 +16,7 @@ fn reachable_with_var_join(edges: &[(u32, u32)]) -> Relation<(u32, u32)> {
     let mut iteration = Iteration::new();
 
     let edges_by_successor = iteration.variable::<(u32, u32)>("edges_invert");
-    edges_by_successor.insert(edges.iter().map(|&(n1, n2)| (n2, n1)).collect());
+    edges_by_successor.extend(edges.iter().map(|&(n1, n2)| (n2, n1)));
 
     let reachable = iteration.variable::<(u32, u32)>("reachable");
     reachable.insert(edges);
@@ -78,10 +78,10 @@ fn sum_join_via_var(
     let mut iteration = Iteration::new();
 
     let input1 = iteration.variable::<(u32, u32)>("input1");
-    input1.insert(input1_slice.iter().collect());
+    input1.extend(input1_slice);
 
     let input2 = iteration.variable::<(u32, u32)>("input1");
-    input2.insert(input2_slice.iter().collect());
+    input2.extend(input2_slice);
 
     let output = iteration.variable::<(u32, u32)>("output");
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,61 @@
+#![cfg(test)]
+
+use crate::Relation;
+use crate::Iteration;
+use crate::RelationLeaper;
+use proptest::prelude::*;
+use proptest::{proptest, proptest_helper};
+
+fn inputs() -> impl Strategy<Value = Vec<(u32, u32)>> {
+    prop::collection::vec((0_u32..100, 0_u32..100), 1..100)
+}
+
+fn reachable_with_join(edges: &[(u32, u32)]) -> Relation<(u32, u32)> {
+    let edges = Relation::from(edges.iter().cloned());
+    let mut iteration = Iteration::new();
+
+    let edges_by_successor = iteration.variable::<(u32, u32)>("edges_invert");
+    edges_by_successor.insert(Relation::from(edges.iter().map(|&(n1, n2)| (n2, n1))));
+
+    let reachable = iteration.variable::<(u32, u32)>("reachable");
+    reachable.insert(edges);
+
+    while iteration.changed() {
+        // reachable(N1, N3) :- edges(N1, N2), reachable(N2, N3).
+        reachable.from_join(&reachable, &edges_by_successor, |&_, &n3, &n1| (n1, n3));
+    }
+
+    reachable.complete()
+}
+
+fn reachable_with_leapfrog(edges: &[(u32, u32)]) -> Relation<(u32, u32)> {
+    let edges = Relation::from(edges.iter().cloned());
+    let mut iteration = Iteration::new();
+
+    let edges_by_successor = Relation::from(edges.iter().map(|&(n1, n2)| (n2, n1)));
+
+    let reachable = iteration.variable::<(u32, u32)>("reachable");
+    reachable.insert(edges);
+
+    while iteration.changed() {
+        // reachable(N1, N3) :- edges(N1, N2), reachable(N2, N3).
+        reachable.from_leapjoin(
+            &reachable,
+            &mut [
+                &mut edges_by_successor.extend_with(|&(n2, _)| n2),
+            ],
+            |&(_, n3), &n1| (n1, n3),
+        );
+    }
+
+    reachable.complete()
+}
+
+proptest! {
+    #[test]
+    fn reachable(edges in inputs()) {
+        let reachable1 = reachable_with_join(&edges);
+        let reachable2 = reachable_with_leapfrog(&edges);
+        assert_eq!(reachable1.elements, reachable2.elements);
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,21 +1,41 @@
 #![cfg(test)]
 
-use crate::Relation;
 use crate::Iteration;
+use crate::Relation;
 use crate::RelationLeaper;
 use proptest::prelude::*;
 use proptest::{proptest, proptest_helper};
 
 fn inputs() -> impl Strategy<Value = Vec<(u32, u32)>> {
-    prop::collection::vec((0_u32..100, 0_u32..100), 1..100)
+    prop::collection::vec((0_u32..100, 0_u32..100), 1..500)
 }
 
-fn reachable_with_join(edges: &[(u32, u32)]) -> Relation<(u32, u32)> {
+/// The original way to use datafrog -- computes reachable nodes from a set of edges
+fn reachable_with_var_join(edges: &[(u32, u32)]) -> Relation<(u32, u32)> {
     let edges = Relation::from(edges.iter().cloned());
     let mut iteration = Iteration::new();
 
     let edges_by_successor = iteration.variable::<(u32, u32)>("edges_invert");
     edges_by_successor.insert(Relation::from(edges.iter().map(|&(n1, n2)| (n2, n1))));
+
+    let reachable = iteration.variable::<(u32, u32)>("reachable");
+    reachable.insert(edges);
+
+    while iteration.changed() {
+        // reachable(N1, N3) :- edges(N1, N2), reachable(N2, N3).
+        reachable.from_join(&reachable, &edges_by_successor, |&_, &n3, &n1| (n1, n3));
+    }
+
+    reachable.complete()
+}
+
+/// Like `reachable`, but using a relation as an input to `from_join`
+fn reachable_with_relation_join(edges: &[(u32, u32)]) -> Relation<(u32, u32)> {
+    let edges = Relation::from(edges.iter().cloned());
+    let mut iteration = Iteration::new();
+
+    // NB. Changed from `reachable_with_var_join`:
+    let edges_by_successor = Relation::from(edges.iter().map(|&(n1, n2)| (n2, n1)));
 
     let reachable = iteration.variable::<(u32, u32)>("reachable");
     reachable.insert(edges);
@@ -41,9 +61,7 @@ fn reachable_with_leapfrog(edges: &[(u32, u32)]) -> Relation<(u32, u32)> {
         // reachable(N1, N3) :- edges(N1, N2), reachable(N2, N3).
         reachable.from_leapjoin(
             &reachable,
-            &mut [
-                &mut edges_by_successor.extend_with(|&(n2, _)| n2),
-            ],
+            &mut [&mut edges_by_successor.extend_with(|&(n2, _)| n2)],
             |&(_, n3), &n1| (n1, n3),
         );
     }
@@ -51,11 +69,60 @@ fn reachable_with_leapfrog(edges: &[(u32, u32)]) -> Relation<(u32, u32)> {
     reachable.complete()
 }
 
+/// Computes a join where the values are summed -- uses iteration
+/// variables (the original datafrog technique).
+fn sum_join_via_var(
+    input1_slice: &[(u32, u32)],
+    input2_slice: &[(u32, u32)],
+) -> Relation<(u32, u32)> {
+    let mut iteration = Iteration::new();
+
+    let input1 = iteration.variable::<(u32, u32)>("input1");
+    input1.insert(Relation::from(input1_slice.iter().cloned()));
+
+    let input2 = iteration.variable::<(u32, u32)>("input1");
+    input2.insert(Relation::from(input2_slice.iter().cloned()));
+
+    let output = iteration.variable::<(u32, u32)>("output");
+
+    while iteration.changed() {
+        // output(K1, V1 * 100 + V2) :- input1(K1, V1), input2(K1, V2).
+        output.from_join(&input1, &input2, |&k1, &v1, &v2| (k1, v1 * 100 + v2));
+    }
+
+    output.complete()
+}
+
+/// Computes a join where the values are summed -- uses iteration
+/// variables (the original datafrog technique).
+fn sum_join_via_relation(
+    input1_slice: &[(u32, u32)],
+    input2_slice: &[(u32, u32)],
+) -> Relation<(u32, u32)> {
+    let input1 = Relation::from(input1_slice.iter().cloned());
+    let input2 = Relation::from(input2_slice.iter().cloned());
+    Relation::from_join(&input1, &input2, |&k1, &v1, &v2| (k1, v1 * 100 + v2))
+}
+
 proptest! {
     #[test]
-    fn reachable(edges in inputs()) {
-        let reachable1 = reachable_with_join(&edges);
+    fn reachable_leapfrog_vs_var_join(edges in inputs()) {
+        let reachable1 = reachable_with_var_join(&edges);
         let reachable2 = reachable_with_leapfrog(&edges);
         assert_eq!(reachable1.elements, reachable2.elements);
+    }
+
+    #[test]
+    fn reachable_rel_join_vs_var_join(edges in inputs()) {
+        let reachable1 = reachable_with_var_join(&edges);
+        let reachable2 = reachable_with_relation_join(&edges);
+        assert_eq!(reachable1.elements, reachable2.elements);
+    }
+
+    #[test]
+    fn sum_join_from_var_vs_rel((set1, set2) in (inputs(), inputs())) {
+        let output1 = sum_join_via_var(&set1, &set2);
+        let output2 = sum_join_via_relation(&set1, &set2);
+        assert_eq!(output1.elements, output2.elements);
     }
 }

--- a/src/treefrog.rs
+++ b/src/treefrog.rs
@@ -46,7 +46,7 @@ pub fn leapjoin_into<'a, Tuple: Ord, Val: Ord + 'a, Result: Ord>(
         }
     }
 
-    output.insert(result.into());
+    output.insert(Relation::from_vec(result));
 }
 
 /// Methods to support treefrog leapjoin.

--- a/src/treefrog.rs
+++ b/src/treefrog.rs
@@ -1,17 +1,17 @@
 //! Join functionality.
 
-use super::{Relation, Variable};
+use super::Relation;
 
 /// Performs treefrog leapjoin using a list of leapers.
 pub(crate) fn leapjoin<'a, Tuple: Ord, Val: Ord + 'a, Result: Ord>(
-    source: &Variable<Tuple>,
+    source: &[Tuple],
     leapers: &mut [&mut dyn Leaper<'a, Tuple, Val>],
     mut logic: impl FnMut(&Tuple, &Val) -> Result,
 ) -> Relation<Result> {
     let mut result = Vec::new(); // temp output storage.
     let mut values = Vec::new(); // temp value storage.
 
-    for tuple in source.recent.borrow().iter() {
+    for tuple in source {
         // Determine which leaper would propose the fewest values.
         let mut min_index = usize::max_value();
         let mut min_count = usize::max_value();

--- a/src/treefrog.rs
+++ b/src/treefrog.rs
@@ -3,12 +3,11 @@
 use super::{Relation, Variable};
 
 /// Performs treefrog leapjoin using a list of leapers.
-pub fn leapjoin_into<'a, Tuple: Ord, Val: Ord + 'a, Result: Ord>(
+pub(crate) fn leapjoin<'a, Tuple: Ord, Val: Ord + 'a, Result: Ord>(
     source: &Variable<Tuple>,
     leapers: &mut [&mut dyn Leaper<'a, Tuple, Val>],
-    output: &Variable<Result>,
     mut logic: impl FnMut(&Tuple, &Val) -> Result,
-) {
+) -> Relation<Result> {
     let mut result = Vec::new(); // temp output storage.
     let mut values = Vec::new(); // temp value storage.
 
@@ -46,7 +45,7 @@ pub fn leapjoin_into<'a, Tuple: Ord, Val: Ord + 'a, Result: Ord>(
         }
     }
 
-    output.insert(Relation::from_vec(result));
+    Relation::from_vec(result)
 }
 
 /// Methods to support treefrog leapjoin.

--- a/src/treefrog.rs
+++ b/src/treefrog.rs
@@ -3,9 +3,9 @@
 use super::Relation;
 
 /// Performs treefrog leapjoin using a list of leapers.
-pub(crate) fn leapjoin<'a, Tuple: Ord, Val: Ord + 'a, Result: Ord>(
+pub(crate) fn leapjoin<'leap, Tuple: Ord, Val: Ord + 'leap, Result: Ord>(
     source: &[Tuple],
-    mut leapers: &mut [&mut dyn Leaper<'a, Tuple, Val>],
+    mut leapers: impl Leapers<'leap, Tuple, Val>,
     mut logic: impl FnMut(&Tuple, &Val) -> Result,
 ) -> Relation<Result> {
     let mut result = Vec::new(); // temp output storage.
@@ -44,56 +44,94 @@ pub(crate) fn leapjoin<'a, Tuple: Ord, Val: Ord + 'a, Result: Ord>(
     Relation::from_vec(result)
 }
 
-pub trait Leapers<'a, Tuple, Val> {
+/// Implemented for a tuple of leapers
+pub trait Leapers<'leap, Tuple, Val> {
+    /// Internal method:
     fn for_each_count(&mut self, tuple: &Tuple, op: impl FnMut(usize, usize));
 
-    fn propose(&mut self, tuple: &Tuple, min_index: usize, values: &mut Vec<&'a Val>);
+    /// Internal method:
+    fn propose(&mut self, tuple: &Tuple, min_index: usize, values: &mut Vec<&'leap Val>);
 
-    fn intersect(&mut self, tuple: &Tuple, min_index: usize, values: &mut Vec<&'a Val>);
+    /// Internal method:
+    fn intersect(&mut self, tuple: &Tuple, min_index: usize, values: &mut Vec<&'leap Val>);
 }
 
-impl<'a, Tuple, Val> Leapers<'a, Tuple, Val> for &mut [&mut dyn Leaper<'a, Tuple, Val>] {
-    fn for_each_count(&mut self, tuple: &Tuple, mut op: impl FnMut(usize, usize)) {
-        for (index, leaper) in self.iter_mut().enumerate() {
-            let count = leaper.count(tuple);
-            op(index, count);
-        }
-    }
+macro_rules! tuple_leapers {
+    ($($Ty:ident)*) => {
+        #[allow(unused_assignments, non_snake_case)]
+        impl<'leap, Tuple, Val, $($Ty),*> Leapers<'leap, Tuple, Val> for ($($Ty,)*)
+        where
+            $($Ty: Leaper<'leap, Tuple, Val>,)*
+        {
+            fn for_each_count(&mut self, tuple: &Tuple, mut op: impl FnMut(usize, usize)) {
+                let ($($Ty,)*) = self;
+                let mut index = 0;
+                $(
+                    let count = $Ty.count(tuple);
+                    op(index, count);
+                    index += 1;
+                )*
+            }
 
-    fn propose(&mut self, tuple: &Tuple, min_index: usize, values: &mut Vec<&'a Val>) {
-        self[min_index].propose(tuple, values);
-    }
+            fn propose(&mut self, tuple: &Tuple, min_index: usize, values: &mut Vec<&'leap Val>) {
+                let ($($Ty,)*) = self;
+                let mut index = 0;
+                $(
+                    if min_index == index {
+                        return $Ty.propose(tuple, values);
+                    }
+                    index += 1;
+                )*
+                    panic!("no match found for min_index={}", min_index);
+            }
 
-    fn intersect(&mut self, tuple: &Tuple, min_index: usize, values: &mut Vec<&'a Val>) {
-        for (index, leaper) in self.iter_mut().enumerate() {
-            if index != min_index {
-                leaper.intersect(tuple, values);
+            fn intersect(&mut self, tuple: &Tuple, min_index: usize, values: &mut Vec<&'leap Val>) {
+                let ($($Ty,)*) = self;
+                let mut index = 0;
+                $(
+                    if min_index != index {
+                        $Ty.intersect(tuple, values);
+                    }
+                    index += 1;
+                )*
             }
         }
     }
 }
 
+tuple_leapers!(A B);
+tuple_leapers!(A B C);
+tuple_leapers!(A B C D);
+tuple_leapers!(A B C D E);
+tuple_leapers!(A B C D E F);
+tuple_leapers!(A B C D E F G);
+
 /// Methods to support treefrog leapjoin.
-pub trait Leaper<'a, Tuple, Val> {
+pub trait Leaper<'leap, Tuple, Val> {
     /// Estimates the number of proposed values.
     fn count(&mut self, prefix: &Tuple) -> usize;
     /// Populates `values` with proposed values.
-    fn propose(&mut self, prefix: &Tuple, values: &mut Vec<&'a Val>);
+    fn propose(&mut self, prefix: &Tuple, values: &mut Vec<&'leap Val>);
     /// Restricts `values` to proposed values.
-    fn intersect(&mut self, prefix: &Tuple, values: &mut Vec<&'a Val>);
+    fn intersect(&mut self, prefix: &Tuple, values: &mut Vec<&'leap Val>);
 }
 
-pub mod filters {
-
+pub(crate) mod filters {
     use super::Leaper;
+    use super::Leapers;
 
-    /// A treefrog leaper based on a per-prefix predicate.
+    /// A treefrog leaper that tests each of the tuples from the main
+    /// input (the "prefix"). Use like `PrefixFilter::from(|tuple|
+    /// ...)`; if the closure returns true, then the tuple is
+    /// retained, else it will be ignored. This leaper can be used in
+    /// isolation in which case it just acts like a filter on the
+    /// input (the "proposed value" will be `()` type).
     pub struct PrefixFilter<Tuple, Func: Fn(&Tuple) -> bool> {
         phantom: ::std::marker::PhantomData<Tuple>,
         predicate: Func,
     }
 
-    impl<'a, Tuple, Func> PrefixFilter<Tuple, Func>
+    impl<'leap, Tuple, Func> PrefixFilter<Tuple, Func>
     where
         Func: Fn(&Tuple) -> bool,
     {
@@ -106,7 +144,7 @@ pub mod filters {
         }
     }
 
-    impl<'a, Tuple, Val, Func> Leaper<'a, Tuple, Val> for PrefixFilter<Tuple, Func>
+    impl<'leap, Tuple, Val, Func> Leaper<'leap, Tuple, Val> for PrefixFilter<Tuple, Func>
     where
         Func: Fn(&Tuple) -> bool,
     {
@@ -119,22 +157,53 @@ pub mod filters {
             }
         }
         /// Populates `values` with proposed values.
-        fn propose(&mut self, _prefix: &Tuple, _values: &mut Vec<&'a Val>) {
+        fn propose(&mut self, _prefix: &Tuple, _values: &mut Vec<&'leap Val>) {
             panic!("PrefixFilter::propose(): variable apparently unbound");
         }
         /// Restricts `values` to proposed values.
-        fn intersect(&mut self, _prefix: &Tuple, _values: &mut Vec<&'a Val>) {
+        fn intersect(&mut self, _prefix: &Tuple, _values: &mut Vec<&'leap Val>) {
             // We can only be here if we returned max_value() above.
         }
     }
 
+    impl<'leap, Tuple, Func> Leapers<'leap, Tuple, ()> for PrefixFilter<Tuple, Func>
+    where
+        Func: Fn(&Tuple) -> bool,
+    {
+        fn for_each_count(&mut self, tuple: &Tuple, mut op: impl FnMut(usize, usize)) {
+            if <Self as Leaper<'_, Tuple, ()>>::count(self, tuple) == 0 {
+                op(0, 0)
+            } else {
+                // we will "propose" the `()` value if the predicate applies
+                op(0, 1)
+            }
+        }
+
+        fn propose(&mut self, _: &Tuple, min_index: usize, values: &mut Vec<&'leap ()>) {
+            assert_eq!(min_index, 0);
+            values.push(&());
+        }
+
+        fn intersect(&mut self, _: &Tuple, min_index: usize, values: &mut Vec<&'leap ()>) {
+            assert_eq!(min_index, 0);
+            assert_eq!(values.len(), 1);
+        }
+    }
+
     /// A treefrog leaper based on a predicate of prefix and value.
+    /// Use like `ValueFilter::from(|tuple, value| ...)`. The closure
+    /// should return true if `value` ought to be retained. The
+    /// `value` will be a value proposed elsewhere by an `extend_with`
+    /// leaper.
+    ///
+    /// This leaper cannot be used in isolation, it must be combined
+    /// with other leapers.
     pub struct ValueFilter<Tuple, Val, Func: Fn(&Tuple, &Val) -> bool> {
         phantom: ::std::marker::PhantomData<(Tuple, Val)>,
         predicate: Func,
     }
 
-    impl<'a, Tuple, Val, Func> ValueFilter<Tuple, Val, Func>
+    impl<'leap, Tuple, Val, Func> ValueFilter<Tuple, Val, Func>
     where
         Func: Fn(&Tuple, &Val) -> bool,
     {
@@ -147,7 +216,7 @@ pub mod filters {
         }
     }
 
-    impl<'a, Tuple, Val, Func> Leaper<'a, Tuple, Val> for ValueFilter<Tuple, Val, Func>
+    impl<'leap, Tuple, Val, Func> Leaper<'leap, Tuple, Val> for ValueFilter<Tuple, Val, Func>
     where
         Func: Fn(&Tuple, &Val) -> bool,
     {
@@ -156,11 +225,11 @@ pub mod filters {
             usize::max_value()
         }
         /// Populates `values` with proposed values.
-        fn propose(&mut self, _prefix: &Tuple, _values: &mut Vec<&'a Val>) {
+        fn propose(&mut self, _prefix: &Tuple, _values: &mut Vec<&'leap Val>) {
             panic!("PrefixFilter::propose(): variable apparently unbound");
         }
         /// Restricts `values` to proposed values.
-        fn intersect(&mut self, prefix: &Tuple, values: &mut Vec<&'a Val>) {
+        fn intersect(&mut self, prefix: &Tuple, values: &mut Vec<&'leap Val>) {
             values.retain(|val| (self.predicate)(prefix, val));
         }
     }
@@ -170,110 +239,110 @@ pub mod filters {
 /// Extension method for relations.
 pub trait RelationLeaper<Key: Ord, Val: Ord> {
     /// Extend with `Val` using the elements of the relation.
-    fn extend_with<'a, Tuple: Ord, Func: Fn(&Tuple) -> Key>(
-        &'a self,
+    fn extend_with<'leap, Tuple: Ord, Func: Fn(&Tuple) -> Key>(
+        &'leap self,
         key_func: Func,
-    ) -> extend_with::ExtendWith<'a, Key, Val, Tuple, Func>
+    ) -> extend_with::ExtendWith<'leap, Key, Val, Tuple, Func>
     where
-        Key: 'a,
-        Val: 'a;
+        Key: 'leap,
+        Val: 'leap;
     /// Extend with `Val` using the complement of the relation.
-    fn extend_anti<'a, Tuple: Ord, Func: Fn(&Tuple) -> Key>(
-        &'a self,
+    fn extend_anti<'leap, Tuple: Ord, Func: Fn(&Tuple) -> Key>(
+        &'leap self,
         key_func: Func,
-    ) -> extend_anti::ExtendAnti<'a, Key, Val, Tuple, Func>
+    ) -> extend_anti::ExtendAnti<'leap, Key, Val, Tuple, Func>
     where
-        Key: 'a,
-        Val: 'a;
+        Key: 'leap,
+        Val: 'leap;
     /// Extend with any value if tuple is present in relation.
-    fn filter_with<'a, Tuple: Ord, Func: Fn(&Tuple) -> (Key, Val)>(
-        &'a self,
+    fn filter_with<'leap, Tuple: Ord, Func: Fn(&Tuple) -> (Key, Val)>(
+        &'leap self,
         key_func: Func,
-    ) -> filter_with::FilterWith<'a, Key, Val, Tuple, Func>
+    ) -> filter_with::FilterWith<'leap, Key, Val, Tuple, Func>
     where
-        Key: 'a,
-        Val: 'a;
+        Key: 'leap,
+        Val: 'leap;
     /// Extend with any value if tuple is absent from relation.
-    fn filter_anti<'a, Tuple: Ord, Func: Fn(&Tuple) -> (Key, Val)>(
-        &'a self,
+    fn filter_anti<'leap, Tuple: Ord, Func: Fn(&Tuple) -> (Key, Val)>(
+        &'leap self,
         key_func: Func,
-    ) -> filter_anti::FilterAnti<'a, Key, Val, Tuple, Func>
+    ) -> filter_anti::FilterAnti<'leap, Key, Val, Tuple, Func>
     where
-        Key: 'a,
-        Val: 'a;
+        Key: 'leap,
+        Val: 'leap;
 }
 
 impl<Key: Ord, Val: Ord> RelationLeaper<Key, Val> for Relation<(Key, Val)> {
-    fn extend_with<'a, Tuple: Ord, Func: Fn(&Tuple) -> Key>(
-        &'a self,
+    fn extend_with<'leap, Tuple: Ord, Func: Fn(&Tuple) -> Key>(
+        &'leap self,
         key_func: Func,
-    ) -> extend_with::ExtendWith<'a, Key, Val, Tuple, Func>
+    ) -> extend_with::ExtendWith<'leap, Key, Val, Tuple, Func>
     where
-        Key: 'a,
-        Val: 'a,
+        Key: 'leap,
+        Val: 'leap,
     {
         extend_with::ExtendWith::from(self, key_func)
     }
-    fn extend_anti<'a, Tuple: Ord, Func: Fn(&Tuple) -> Key>(
-        &'a self,
+    fn extend_anti<'leap, Tuple: Ord, Func: Fn(&Tuple) -> Key>(
+        &'leap self,
         key_func: Func,
-    ) -> extend_anti::ExtendAnti<'a, Key, Val, Tuple, Func>
+    ) -> extend_anti::ExtendAnti<'leap, Key, Val, Tuple, Func>
     where
-        Key: 'a,
-        Val: 'a,
+        Key: 'leap,
+        Val: 'leap,
     {
         extend_anti::ExtendAnti::from(self, key_func)
     }
-    fn filter_with<'a, Tuple: Ord, Func: Fn(&Tuple) -> (Key, Val)>(
-        &'a self,
+    fn filter_with<'leap, Tuple: Ord, Func: Fn(&Tuple) -> (Key, Val)>(
+        &'leap self,
         key_func: Func,
-    ) -> filter_with::FilterWith<'a, Key, Val, Tuple, Func>
+    ) -> filter_with::FilterWith<'leap, Key, Val, Tuple, Func>
     where
-        Key: 'a,
-        Val: 'a,
+        Key: 'leap,
+        Val: 'leap,
     {
         filter_with::FilterWith::from(self, key_func)
     }
-    fn filter_anti<'a, Tuple: Ord, Func: Fn(&Tuple) -> (Key, Val)>(
-        &'a self,
+    fn filter_anti<'leap, Tuple: Ord, Func: Fn(&Tuple) -> (Key, Val)>(
+        &'leap self,
         key_func: Func,
-    ) -> filter_anti::FilterAnti<'a, Key, Val, Tuple, Func>
+    ) -> filter_anti::FilterAnti<'leap, Key, Val, Tuple, Func>
     where
-        Key: 'a,
-        Val: 'a,
+        Key: 'leap,
+        Val: 'leap,
     {
         filter_anti::FilterAnti::from(self, key_func)
     }
 }
 
 pub(crate) mod extend_with {
-    use super::{binary_search, Leaper, Relation};
+    use super::{binary_search, Leaper, Leapers, Relation};
     use crate::join::gallop;
 
     /// Wraps a Relation<Tuple> as a leaper.
-    pub struct ExtendWith<'a, Key, Val, Tuple, Func>
+    pub struct ExtendWith<'leap, Key, Val, Tuple, Func>
     where
-        Key: Ord + 'a,
-        Val: Ord + 'a,
+        Key: Ord + 'leap,
+        Val: Ord + 'leap,
         Tuple: Ord,
         Func: Fn(&Tuple) -> Key,
     {
-        relation: &'a Relation<(Key, Val)>,
+        relation: &'leap Relation<(Key, Val)>,
         start: usize,
         end: usize,
         key_func: Func,
         phantom: ::std::marker::PhantomData<Tuple>,
     }
 
-    impl<'a, Key, Val, Tuple, Func> ExtendWith<'a, Key, Val, Tuple, Func>
+    impl<'leap, Key, Val, Tuple, Func> ExtendWith<'leap, Key, Val, Tuple, Func>
     where
-        Key: Ord + 'a,
-        Val: Ord + 'a,
+        Key: Ord + 'leap,
+        Val: Ord + 'leap,
         Tuple: Ord,
         Func: Fn(&Tuple) -> Key,
     {
         /// Constructs a ExtendWith from a relation and key and value function.
-        pub fn from(relation: &'a Relation<(Key, Val)>, key_func: Func) -> Self {
+        pub fn from(relation: &'leap Relation<(Key, Val)>, key_func: Func) -> Self {
             ExtendWith {
                 relation,
                 start: 0,
@@ -284,10 +353,11 @@ pub(crate) mod extend_with {
         }
     }
 
-    impl<'a, Key, Val, Tuple, Func> Leaper<'a, Tuple, Val> for ExtendWith<'a, Key, Val, Tuple, Func>
+    impl<'leap, Key, Val, Tuple, Func> Leaper<'leap, Tuple, Val>
+        for ExtendWith<'leap, Key, Val, Tuple, Func>
     where
-        Key: Ord + 'a,
-        Val: Ord + 'a,
+        Key: Ord + 'leap,
+        Val: Ord + 'leap,
         Tuple: Ord,
         Func: Fn(&Tuple) -> Key,
     {
@@ -299,16 +369,38 @@ pub(crate) mod extend_with {
             self.end = self.relation.len() - slice2.len();
             slice1.len() - slice2.len()
         }
-        fn propose(&mut self, _prefix: &Tuple, values: &mut Vec<&'a Val>) {
+        fn propose(&mut self, _prefix: &Tuple, values: &mut Vec<&'leap Val>) {
             let slice = &self.relation[self.start..self.end];
             values.extend(slice.iter().map(|&(_, ref val)| val));
         }
-        fn intersect(&mut self, _prefix: &Tuple, values: &mut Vec<&'a Val>) {
+        fn intersect(&mut self, _prefix: &Tuple, values: &mut Vec<&'leap Val>) {
             let mut slice = &self.relation[self.start..self.end];
             values.retain(|v| {
                 slice = gallop(slice, |kv| &kv.1 < v);
                 slice.get(0).map(|kv| &kv.1) == Some(v)
             });
+        }
+    }
+
+    impl<'leap, Key, Val, Tuple, Func> Leapers<'leap, Tuple, Val>
+        for ExtendWith<'leap, Key, Val, Tuple, Func>
+    where
+        Key: Ord + 'leap,
+        Val: Ord + 'leap,
+        Tuple: Ord,
+        Func: Fn(&Tuple) -> Key,
+    {
+        fn for_each_count(&mut self, tuple: &Tuple, mut op: impl FnMut(usize, usize)) {
+            op(0, self.count(tuple))
+        }
+
+        fn propose(&mut self, tuple: &Tuple, min_index: usize, values: &mut Vec<&'leap Val>) {
+            assert_eq!(min_index, 0);
+            Leaper::propose(self, tuple, values);
+        }
+
+        fn intersect(&mut self, _: &Tuple, min_index: usize, _: &mut Vec<&'leap Val>) {
+            assert_eq!(min_index, 0);
         }
     }
 }
@@ -318,27 +410,27 @@ pub(crate) mod extend_anti {
     use crate::join::gallop;
 
     /// Wraps a Relation<Tuple> as a leaper.
-    pub struct ExtendAnti<'a, Key, Val, Tuple, Func>
+    pub struct ExtendAnti<'leap, Key, Val, Tuple, Func>
     where
-        Key: Ord + 'a,
-        Val: Ord + 'a,
+        Key: Ord + 'leap,
+        Val: Ord + 'leap,
         Tuple: Ord,
         Func: Fn(&Tuple) -> Key,
     {
-        relation: &'a Relation<(Key, Val)>,
+        relation: &'leap Relation<(Key, Val)>,
         key_func: Func,
         phantom: ::std::marker::PhantomData<Tuple>,
     }
 
-    impl<'a, Key, Val, Tuple, Func> ExtendAnti<'a, Key, Val, Tuple, Func>
+    impl<'leap, Key, Val, Tuple, Func> ExtendAnti<'leap, Key, Val, Tuple, Func>
     where
-        Key: Ord + 'a,
-        Val: Ord + 'a,
+        Key: Ord + 'leap,
+        Val: Ord + 'leap,
         Tuple: Ord,
         Func: Fn(&Tuple) -> Key,
     {
         /// Constructs a ExtendAnti from a relation and key and value function.
-        pub fn from(relation: &'a Relation<(Key, Val)>, key_func: Func) -> Self {
+        pub fn from(relation: &'leap Relation<(Key, Val)>, key_func: Func) -> Self {
             ExtendAnti {
                 relation,
                 key_func,
@@ -347,21 +439,21 @@ pub(crate) mod extend_anti {
         }
     }
 
-    impl<'a, Key: Ord, Val: Ord + 'a, Tuple: Ord, Func: Fn(&Tuple) -> Key> Leaper<'a, Tuple, Val>
-        for ExtendAnti<'a, Key, Val, Tuple, Func>
+    impl<'leap, Key: Ord, Val: Ord + 'leap, Tuple: Ord, Func: Fn(&Tuple) -> Key>
+        Leaper<'leap, Tuple, Val> for ExtendAnti<'leap, Key, Val, Tuple, Func>
     where
-        Key: Ord + 'a,
-        Val: Ord + 'a,
+        Key: Ord + 'leap,
+        Val: Ord + 'leap,
         Tuple: Ord,
         Func: Fn(&Tuple) -> Key,
     {
         fn count(&mut self, _prefix: &Tuple) -> usize {
             usize::max_value()
         }
-        fn propose(&mut self, _prefix: &Tuple, _values: &mut Vec<&'a Val>) {
+        fn propose(&mut self, _prefix: &Tuple, _values: &mut Vec<&'leap Val>) {
             panic!("ExtendAnti::propose(): variable apparently unbound.");
         }
-        fn intersect(&mut self, prefix: &Tuple, values: &mut Vec<&'a Val>) {
+        fn intersect(&mut self, prefix: &Tuple, values: &mut Vec<&'leap Val>) {
             let key = (self.key_func)(prefix);
             let start = binary_search(&self.relation[..], |x| &x.0 < &key);
             let slice1 = &self.relation[start..];
@@ -379,30 +471,30 @@ pub(crate) mod extend_anti {
 
 pub(crate) mod filter_with {
 
-    use super::{Leaper, Relation};
+    use super::{Leaper, Leapers, Relation};
 
     /// Wraps a Relation<Tuple> as a leaper.
-    pub struct FilterWith<'a, Key, Val, Tuple, Func>
+    pub struct FilterWith<'leap, Key, Val, Tuple, Func>
     where
-        Key: Ord + 'a,
-        Val: Ord + 'a,
+        Key: Ord + 'leap,
+        Val: Ord + 'leap,
         Tuple: Ord,
         Func: Fn(&Tuple) -> (Key, Val),
     {
-        relation: &'a Relation<(Key, Val)>,
+        relation: &'leap Relation<(Key, Val)>,
         key_func: Func,
         phantom: ::std::marker::PhantomData<Tuple>,
     }
 
-    impl<'a, Key, Val, Tuple, Func> FilterWith<'a, Key, Val, Tuple, Func>
+    impl<'leap, Key, Val, Tuple, Func> FilterWith<'leap, Key, Val, Tuple, Func>
     where
-        Key: Ord + 'a,
-        Val: Ord + 'a,
+        Key: Ord + 'leap,
+        Val: Ord + 'leap,
         Tuple: Ord,
         Func: Fn(&Tuple) -> (Key, Val),
     {
         /// Constructs a FilterWith from a relation and key and value function.
-        pub fn from(relation: &'a Relation<(Key, Val)>, key_func: Func) -> Self {
+        pub fn from(relation: &'leap Relation<(Key, Val)>, key_func: Func) -> Self {
             FilterWith {
                 relation,
                 key_func,
@@ -411,11 +503,11 @@ pub(crate) mod filter_with {
         }
     }
 
-    impl<'a, Key, Val, Val2, Tuple, Func> Leaper<'a, Tuple, Val2>
-        for FilterWith<'a, Key, Val, Tuple, Func>
+    impl<'leap, Key, Val, Val2, Tuple, Func> Leaper<'leap, Tuple, Val2>
+        for FilterWith<'leap, Key, Val, Tuple, Func>
     where
-        Key: Ord + 'a,
-        Val: Ord + 'a,
+        Key: Ord + 'leap,
+        Val: Ord + 'leap,
         Tuple: Ord,
         Func: Fn(&Tuple) -> (Key, Val),
     {
@@ -427,41 +519,68 @@ pub(crate) mod filter_with {
                 0
             }
         }
-        fn propose(&mut self, _prefix: &Tuple, _values: &mut Vec<&'a Val2>) {
+        fn propose(&mut self, _prefix: &Tuple, _values: &mut Vec<&'leap Val2>) {
             panic!("FilterWith::propose(): variable apparently unbound.");
         }
-        fn intersect(&mut self, _prefix: &Tuple, _values: &mut Vec<&'a Val2>) {
+        fn intersect(&mut self, _prefix: &Tuple, _values: &mut Vec<&'leap Val2>) {
             // Only here because we didn't return zero above, right?
+        }
+    }
+
+    impl<'leap, Key, Val, Tuple, Func> Leapers<'leap, Tuple, ()>
+        for FilterWith<'leap, Key, Val, Tuple, Func>
+    where
+        Key: Ord + 'leap,
+        Val: Ord + 'leap,
+        Tuple: Ord,
+        Func: Fn(&Tuple) -> (Key, Val),
+    {
+        fn for_each_count(&mut self, tuple: &Tuple, mut op: impl FnMut(usize, usize)) {
+            if <Self as Leaper<Tuple, ()>>::count(self, tuple) == 0 {
+                op(0, 0)
+            } else {
+                op(0, 1)
+            }
+        }
+
+        fn propose(&mut self, _: &Tuple, min_index: usize, values: &mut Vec<&'leap ()>) {
+            assert_eq!(min_index, 0);
+            values.push(&());
+        }
+
+        fn intersect(&mut self, _: &Tuple, min_index: usize, values: &mut Vec<&'leap ()>) {
+            assert_eq!(min_index, 0);
+            assert_eq!(values.len(), 1);
         }
     }
 }
 
 pub(crate) mod filter_anti {
 
-    use super::{Leaper, Relation};
+    use super::{Leaper, Leapers, Relation};
 
     /// Wraps a Relation<Tuple> as a leaper.
-    pub struct FilterAnti<'a, Key, Val, Tuple, Func>
+    pub struct FilterAnti<'leap, Key, Val, Tuple, Func>
     where
-        Key: Ord + 'a,
-        Val: Ord + 'a,
+        Key: Ord + 'leap,
+        Val: Ord + 'leap,
         Tuple: Ord,
         Func: Fn(&Tuple) -> (Key, Val),
     {
-        relation: &'a Relation<(Key, Val)>,
+        relation: &'leap Relation<(Key, Val)>,
         key_func: Func,
         phantom: ::std::marker::PhantomData<Tuple>,
     }
 
-    impl<'a, Key, Val, Tuple, Func> FilterAnti<'a, Key, Val, Tuple, Func>
+    impl<'leap, Key, Val, Tuple, Func> FilterAnti<'leap, Key, Val, Tuple, Func>
     where
-        Key: Ord + 'a,
-        Val: Ord + 'a,
+        Key: Ord + 'leap,
+        Val: Ord + 'leap,
         Tuple: Ord,
         Func: Fn(&Tuple) -> (Key, Val),
     {
         /// Constructs a FilterAnti from a relation and key and value function.
-        pub fn from(relation: &'a Relation<(Key, Val)>, key_func: Func) -> Self {
+        pub fn from(relation: &'leap Relation<(Key, Val)>, key_func: Func) -> Self {
             FilterAnti {
                 relation,
                 key_func,
@@ -470,11 +589,11 @@ pub(crate) mod filter_anti {
         }
     }
 
-    impl<'a, Key: Ord, Val: Ord + 'a, Val2, Tuple: Ord, Func: Fn(&Tuple) -> (Key, Val)>
-        Leaper<'a, Tuple, Val2> for FilterAnti<'a, Key, Val, Tuple, Func>
+    impl<'leap, Key: Ord, Val: Ord + 'leap, Val2, Tuple: Ord, Func: Fn(&Tuple) -> (Key, Val)>
+        Leaper<'leap, Tuple, Val2> for FilterAnti<'leap, Key, Val, Tuple, Func>
     where
-        Key: Ord + 'a,
-        Val: Ord + 'a,
+        Key: Ord + 'leap,
+        Val: Ord + 'leap,
         Tuple: Ord,
         Func: Fn(&Tuple) -> (Key, Val),
     {
@@ -486,11 +605,40 @@ pub(crate) mod filter_anti {
                 usize::max_value()
             }
         }
-        fn propose(&mut self, _prefix: &Tuple, _values: &mut Vec<&'a Val2>) {
+        fn propose(&mut self, _prefix: &Tuple, _values: &mut Vec<&'leap Val2>) {
             panic!("FilterAnti::propose(): variable apparently unbound.");
         }
-        fn intersect(&mut self, _prefix: &Tuple, _values: &mut Vec<&'a Val2>) {
+        fn intersect(&mut self, _prefix: &Tuple, _values: &mut Vec<&'leap Val2>) {
             // Only here because we didn't return zero above, right?
+        }
+    }
+
+    impl<'leap, Key, Val, Tuple, Func> Leapers<'leap, Tuple, ()>
+        for FilterAnti<'leap, Key, Val, Tuple, Func>
+    where
+        Key: Ord + 'leap,
+        Val: Ord + 'leap,
+        Tuple: Ord,
+        Func: Fn(&Tuple) -> (Key, Val),
+    {
+        fn for_each_count(&mut self, tuple: &Tuple, mut op: impl FnMut(usize, usize)) {
+            if <Self as Leaper<Tuple, ()>>::count(self, tuple) == 0 {
+                op(0, 0)
+            } else {
+                op(0, 1)
+            }
+        }
+
+        fn propose(&mut self, _: &Tuple, min_index: usize, values: &mut Vec<&'leap ()>) {
+            // We only get here if `tuple` is *not* a member of `self.relation`
+            assert_eq!(min_index, 0);
+            values.push(&());
+        }
+
+        fn intersect(&mut self, _: &Tuple, min_index: usize, values: &mut Vec<&'leap ()>) {
+            // We only get here if `tuple` is not a member of `self.relation`
+            assert_eq!(min_index, 0);
+            assert_eq!(values.len(), 1);
         }
     }
 }

--- a/src/treefrog.rs
+++ b/src/treefrog.rs
@@ -224,7 +224,7 @@ impl<Key: Ord, Val: Ord> RelationLeaper<Key, Val> for Relation<(Key, Val)> {
 
 pub(crate) mod extend_with {
     use super::{binary_search, Leaper, Relation};
-    use join::gallop;
+    use crate::join::gallop;
 
     /// Wraps a Relation<Tuple> as a leaper.
     pub struct ExtendWith<'a, Key, Val, Tuple, Func>
@@ -291,7 +291,7 @@ pub(crate) mod extend_with {
 
 pub(crate) mod extend_anti {
     use super::{binary_search, Leaper, Relation};
-    use join::gallop;
+    use crate::join::gallop;
 
     /// Wraps a Relation<Tuple> as a leaper.
     pub struct ExtendAnti<'a, Key, Val, Tuple, Func>


### PR DESCRIPTION
While doing some work using datafrog, I got annoyed about the need to create intermediate variables and things instead of being able to work directly with relations. I also noticed that `Relation::from`, which currently takes an iterator and collects to an intermediate vector, introduces a certain amount of inefficiency. (As an example, `from_leapjoin` seems to be making an extra vector on each iteration.)

This branch aims to correct both things:

- It makes `Relation::from` equivalent to `Relation::from_vec` instead of `Relation::from_iter`
    - it also implements `FromIterator` for `Relation`, so you can do `let foo: Relation = iter.collect()`
    - (this is the breaking change)
- It extends `Relation` with a number of methods, like `Relation::from_join`, `Relation::from_antijoin`, and `Relation::from_leapjoin`
- It extends `Variable` with an `extend` method, equivalent to `.insert(Relation::from_iter(...))`
- It extends `Variable::from_join` with the ability to take one argument that is a relation
    - the tuples in the relation are treated as "stable" tuples
    - if you have *two* relations to join, you can use `Relation::from_join` instead

One side effect of this change is that you can often pull computation out from the "while loop" of the iteration and instead just construct `Relation` tuples directly. It seems to me that this *must* be more efficient, but @frankmcsherry I'd be curious if you think I am wrong.

cc @lqd, @frankmcsherry 