### PR TITLE
release datafrog 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datafrog"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Frank McSherry <fmcsherry@me.com>", "The Rust Project Developers", "Datafrog Developers"]
 license = "Apache-2.0/MIT"
 description = "Lightweight Datalog engine intended to be embedded in other Rust programs"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,16 @@
+# 2.0.0
+
+- Breaking changes:
+  - leapjoin now takes a tuple of leapers, and not a `&mut` slice:
+    - `from_leapjoin(&input, &mut [&mut foo.extend_with(...), ..], ..)` becomes
+      `from_leapjoin(&input, (foo.extend_with(...), ..), ..)`
+    - if there is only one leaper, no tuple is needed
+  - `Relation::from` now requires a vector, not an iterator; use
+    `Relation::from_iter` instead
+- Changed the API to permit using `Relation` and `Variable` more interchangeably,
+  and added a number of operations to construct relations directly, like `Relation::from_join`
+- Extended leapfrog triejoin with new operations (`PrefixFilter` and `ValueFilter`)
+
 # 1.0.0
 
 - Added leapfrog triejoin (#11).


### PR DESCRIPTION
- Breaking changes:
  - leapjoin now takes a tuple of leapers, and not a `&mut` slice:
    - `from_leapjoin(&input, &mut [&mut foo.extend_with(...), ..], ..)` becomes
      `from_leapjoin(&input, (foo.extend_with(...), ..), ..)`
    - if there is only one leaper, no tuple is needed
  - `Relation::from` now requires a vector, not an iterator; use
    `Relation::from_iter` instead
- Changed the API to permit using `Relation` and `Variable` more interchangeably,
  and added a number of operations to construct relations directly, like `Relation::from_join`
- Extended leapfrog triejoin with new operations (`PrefixFilter` and `ValueFilter`)