### PR TITLE
Work around rustdoc ICE, and fix a doc link

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ impl<Tuple: Ord> Relation<Tuple> {
     }
 
     /// Creates a `Relation` using the `leapjoin` logic;
-    /// see [`Variable::leapjoin`]
+    /// see [`Variable::from_leapjoin`]
     pub fn from_leapjoin<'leap, SourceTuple: Ord, Val: Ord + 'leap>(
         source: &Relation<SourceTuple>,
         leapers: impl Leapers<'leap, SourceTuple, Val>,

--- a/src/treefrog.rs
+++ b/src/treefrog.rs
@@ -439,8 +439,8 @@ pub(crate) mod extend_anti {
         }
     }
 
-    impl<'leap, Key: Ord, Val: Ord + 'leap, Tuple: Ord, Func>
-        Leaper<'leap, Tuple, Val> for ExtendAnti<'leap, Key, Val, Tuple, Func>
+    impl<'leap, Key: Ord, Val: Ord + 'leap, Tuple: Ord, Func> Leaper<'leap, Tuple, Val>
+        for ExtendAnti<'leap, Key, Val, Tuple, Func>
     where
         Key: Ord + 'leap,
         Val: Ord + 'leap,
@@ -589,8 +589,8 @@ pub(crate) mod filter_anti {
         }
     }
 
-    impl<'leap, Key: Ord, Val: Ord + 'leap, Val2, Tuple: Ord, Func>
-        Leaper<'leap, Tuple, Val2> for FilterAnti<'leap, Key, Val, Tuple, Func>
+    impl<'leap, Key: Ord, Val: Ord + 'leap, Val2, Tuple: Ord, Func> Leaper<'leap, Tuple, Val2>
+        for FilterAnti<'leap, Key, Val, Tuple, Func>
     where
         Key: Ord + 'leap,
         Val: Ord + 'leap,

--- a/src/treefrog.rs
+++ b/src/treefrog.rs
@@ -439,7 +439,7 @@ pub(crate) mod extend_anti {
         }
     }
 
-    impl<'leap, Key: Ord, Val: Ord + 'leap, Tuple: Ord, Func: Fn(&Tuple) -> Key>
+    impl<'leap, Key: Ord, Val: Ord + 'leap, Tuple: Ord, Func>
         Leaper<'leap, Tuple, Val> for ExtendAnti<'leap, Key, Val, Tuple, Func>
     where
         Key: Ord + 'leap,
@@ -589,7 +589,7 @@ pub(crate) mod filter_anti {
         }
     }
 
-    impl<'leap, Key: Ord, Val: Ord + 'leap, Val2, Tuple: Ord, Func: Fn(&Tuple) -> (Key, Val)>
+    impl<'leap, Key: Ord, Val: Ord + 'leap, Val2, Tuple: Ord, Func>
         Leaper<'leap, Tuple, Val2> for FilterAnti<'leap, Key, Val, Tuple, Func>
     where
         Key: Ord + 'leap,


### PR DESCRIPTION
This works around https://github.com/rust-lang/rust/issues/57180 by removing the duplicate `Func` bounds — which make rustdoc crash in crates depending on datafrog.

(Also fixes a broken doc link.)

This will likely require publishing a 2.0.1, so that polonius can incorporate the fix into the (currently failing) PR updating polonius and datafrog in rustc, to be able to land.

r? @nikomatsakis 