### PR TITLE
release v2.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datafrog"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Frank McSherry <fmcsherry@me.com>", "The Rust Project Developers", "Datafrog Developers"]
 license = "Apache-2.0/MIT"
 description = "Lightweight Datalog engine intended to be embedded in other Rust programs"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,7 @@
+# 2.0.1
+
+- Work around a rustdoc ICE (#24)
+
 # 2.0.0
 
 - Breaking changes:


### PR DESCRIPTION
# 2.0.1

- Work around a rustdoc ICE (#24)